### PR TITLE
[Week-2] Implement user profile endpoints

### DIFF
--- a/application/internal/domain/user.go
+++ b/application/internal/domain/user.go
@@ -5,5 +5,6 @@ type User struct {
 	Email    string
 	Password string
 	Birthday string
+	Nickname string
 	Intro    string
 }

--- a/application/internal/handler/user.go
+++ b/application/internal/handler/user.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"github.com/Jadepypy/distributed-social-media/application/internal/domain"
 	"github.com/Jadepypy/distributed-social-media/application/internal/usecase"
 	"github.com/gin-gonic/gin"
@@ -22,8 +21,6 @@ func NewUserHandler(useCase usecase.UserUseCase) *UserHandler {
 }
 
 func (u *UserHandler) RegisterRoutes(server *gin.Engine) {
-	fmt.Println("receive!!!2")
-
 	userGroup := server.Group("/user")
 	userGroup.POST("/signup", u.SignUp)
 	userGroup.POST("/login", u.Login)

--- a/application/internal/handler/user.go
+++ b/application/internal/handler/user.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"github.com/Jadepypy/distributed-social-media/application/internal/domain"
 	"github.com/Jadepypy/distributed-social-media/application/internal/usecase"
 	"github.com/gin-contrib/sessions"
@@ -43,8 +42,6 @@ func (u *UserHandler) SignUp(ctx *gin.Context) {
 	}
 
 	// TODO: validate request
-
-	fmt.Println("req", req.Email, req.Password)
 	if strings.Compare(req.Password, req.ConfirmPassword) != 0 {
 		ctx.JSON(http.StatusOK, gin.H{
 			"message": "password does not match",
@@ -100,6 +97,33 @@ func (u *UserHandler) Login(ctx *gin.Context) {
 }
 
 func (u *UserHandler) Edit(ctx *gin.Context) {
+	type EditReq struct {
+		Birthday string `json:"birthday"`
+		Intro    string `json:"intro"`
+		Nickname string `json:"nickname"`
+	}
+
+	var req EditReq
+	if err := ctx.Bind(&req); err != nil {
+		return
+	}
+
+	err := u.useCase.Edit(ctx, domain.User{
+		Birthday: req.Birthday,
+		Intro:    req.Intro,
+		Nickname: req.Nickname,
+	})
+
+	if err != nil {
+		ctx.JSON(http.StatusOK, gin.H{
+			"message": err.Error(),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message": "success",
+	})
 }
 
 func (u *UserHandler) Profile(ctx *gin.Context) {

--- a/application/internal/handler/user.go
+++ b/application/internal/handler/user.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Jadepypy/distributed-social-media/application/internal/domain"
 	"github.com/Jadepypy/distributed-social-media/application/internal/usecase"
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"strings"
@@ -88,6 +89,10 @@ func (u *UserHandler) Login(ctx *gin.Context) {
 		})
 		return
 	}
+
+	sess := sessions.Default(ctx)
+	sess.Set("user_id", req.Email)
+	sess.Save()
 
 	ctx.JSON(http.StatusOK, gin.H{
 		"message": "success",

--- a/application/internal/handler/user.go
+++ b/application/internal/handler/user.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"github.com/Jadepypy/distributed-social-media/application/internal/domain"
 	"github.com/Jadepypy/distributed-social-media/application/internal/usecase"
 	"github.com/gin-gonic/gin"
@@ -42,6 +43,7 @@ func (u *UserHandler) SignUp(ctx *gin.Context) {
 
 	// TODO: validate request
 
+	fmt.Println("req", req.Email, req.Password)
 	if strings.Compare(req.Password, req.ConfirmPassword) != 0 {
 		ctx.JSON(http.StatusOK, gin.H{
 			"message": "password does not match",
@@ -66,6 +68,30 @@ func (u *UserHandler) SignUp(ctx *gin.Context) {
 }
 
 func (u *UserHandler) Login(ctx *gin.Context) {
+	type LogInReq struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+
+	var req LogInReq
+	if err := ctx.Bind(&req); err != nil {
+		return
+	}
+
+	err := u.useCase.LogIn(ctx, domain.User{
+		Email:    req.Email,
+		Password: req.Password,
+	})
+	if err != nil {
+		ctx.JSON(http.StatusOK, gin.H{
+			"message": err.Error(),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message": "success",
+	})
 }
 
 func (u *UserHandler) Edit(ctx *gin.Context) {

--- a/application/internal/middleware/login.go
+++ b/application/internal/middleware/login.go
@@ -21,6 +21,7 @@ func (m *LogInMiddlewareBuilder) CheckLogIn() gin.HandlerFunc {
 			c.JSON(401, gin.H{"message": "Not logged in"})
 			c.Abort()
 		} else {
+			c.Set("user_id", userID)
 			c.Next()
 		}
 	}

--- a/application/internal/middleware/login.go
+++ b/application/internal/middleware/login.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+)
+
+type LogInMiddlewareBuilder struct{}
+
+func (m *LogInMiddlewareBuilder) CheckLogIn() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		path := c.Request.URL.Path
+		if path == "/user/login" || path == "/user/signup" {
+			c.Next()
+			return
+		}
+
+		sess := sessions.Default(c)
+		userID := sess.Get("user_id")
+		if userID == nil {
+			c.JSON(401, gin.H{"message": "Not logged in"})
+			c.Abort()
+		} else {
+			c.Next()
+		}
+	}
+}

--- a/application/internal/repository/dao/user.go
+++ b/application/internal/repository/dao/user.go
@@ -6,18 +6,19 @@ import (
 	"time"
 )
 
+// TODO: use embedding struct for user profile
 type User struct {
-	Id       int64  `gorm:"primaryKey,autoIncrement"`
-	Email    string `gorm:"unique,not null"`
-	Password string `gorm:"not null"`
-	Birthday string `gorm:"default:null"`
-	Nickname string
-	Intro    string
+	Id       int64   `gorm:"primaryKey,autoIncrement"`
+	Email    string  `gorm:"unique,not null"`
+	Password string  `gorm:"not null"`
+	Birthday *string `gorm:"default:null"`
+	Nickname *string
+	Intro    *string
 
 	// ms, UTF+0:00
 	CreatedAt int64
 	// ms, UTF+0:00
-	UpdatedAt int64
+	UpdatedAt int64 `gorm:"autoUpdateTime:milli"`
 }
 
 func NewUserDao(db *gorm.DB) UserDAO {
@@ -29,7 +30,7 @@ func NewUserDao(db *gorm.DB) UserDAO {
 type UserDAO interface {
 	GetByEmail(ctx context.Context, email string) (User, error)
 	Insert(ctx context.Context, user User) error
-	Update(ctx context.Context, user User) error
+	Update(ctx context.Context, email string, user User) error
 }
 
 type userDao struct {
@@ -53,7 +54,6 @@ func (u *userDao) Insert(ctx context.Context, user User) error {
 	return u.db.Create(&user).Error
 }
 
-func (u *userDao) Update(ctx context.Context, user User) error {
-	//TODO implement me
-	panic("implement me")
+func (u *userDao) Update(ctx context.Context, email string, user User) error {
+	return u.db.Model(&User{}).Where("email = ?", email).Updates(user).Error
 }

--- a/application/internal/repository/dao/user.go
+++ b/application/internal/repository/dao/user.go
@@ -2,14 +2,15 @@ package dao
 
 import (
 	"context"
-	"database/sql"
 	"gorm.io/gorm"
+	"time"
 )
 
 type User struct {
-	Id       int64          `gorm:"primaryKey,autoIncrement"`
-	Email    sql.NullString `gorm:"unique"`
-	Password string
+	Id       int64  `gorm:"primaryKey,autoIncrement"`
+	Email    string `gorm:"unique,not null"`
+	Password string `gorm:"not null"`
+	Birthday string `gorm:"default:null"`
 	Nickname string
 	Intro    string
 
@@ -36,13 +37,20 @@ type userDao struct {
 }
 
 func (u *userDao) GetByEmail(ctx context.Context, email string) (User, error) {
-	//TODO implement me
-	panic("implement me")
+	var user User
+	if err := u.db.Where("email = ?", email).First(&user).Error; err != nil {
+		return User{}, err
+	}
+	return user, nil
 }
 
 func (u *userDao) Insert(ctx context.Context, user User) error {
-	//TODO implement me
-	panic("implement me")
+	now := time.Now().UnixMilli()
+	user.CreatedAt = now
+	user.UpdatedAt = now
+
+	// TODO: customize email unique constraint error
+	return u.db.Create(&user).Error
 }
 
 func (u *userDao) Update(ctx context.Context, user User) error {

--- a/application/internal/repository/user.go
+++ b/application/internal/repository/user.go
@@ -1,15 +1,16 @@
 package repository
 
 import (
+	"context"
 	"github.com/Jadepypy/distributed-social-media/application/internal/domain"
 	"github.com/Jadepypy/distributed-social-media/application/internal/repository/dao"
 	"gorm.io/gorm"
 )
 
 type UserRepository interface {
-	CreateUser(user domain.User) error
-	GetUserByEmail(email string) (domain.User, error)
-	UpdateUser(user domain.User) error
+	CreateUser(ctx context.Context, user domain.User) error
+	GetUserByEmail(ctx context.Context, email string) (domain.User, error)
+	UpdateUser(ctx context.Context, user domain.User) error
 }
 
 type userRepository struct {
@@ -22,17 +23,32 @@ func NewUserRepository(db *gorm.DB) UserRepository {
 	}
 }
 
-func (u *userRepository) CreateUser(user domain.User) error {
+func (u *userRepository) CreateUser(ctx context.Context, user domain.User) error {
+	return u.dao.Insert(ctx, dao.User{
+		Email:    user.Email,
+		Password: user.Password,
+	})
+}
+
+func (u *userRepository) GetUserByEmail(ctx context.Context, email string) (domain.User, error) {
+	user, err := u.dao.GetByEmail(ctx, email)
+	if err != nil {
+		return domain.User{}, err
+	}
+	return daoToDomain(user), nil
+}
+
+func (u *userRepository) UpdateUser(ctx context.Context, user domain.User) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (u *userRepository) GetUserByEmail(email string) (domain.User, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (u *userRepository) UpdateUser(user domain.User) error {
-	//TODO implement me
-	panic("implement me")
+func daoToDomain(user dao.User) domain.User {
+	return domain.User{
+		Email:    user.Email,
+		Password: user.Password,
+		Birthday: user.Birthday,
+		Nickname: user.Nickname,
+		Intro:    user.Intro,
+	}
 }

--- a/application/internal/repository/user.go
+++ b/application/internal/repository/user.go
@@ -39,16 +39,35 @@ func (u *userRepository) GetUserByEmail(ctx context.Context, email string) (doma
 }
 
 func (u *userRepository) UpdateUser(ctx context.Context, user domain.User) error {
-	//TODO implement me
-	panic("implement me")
+	return u.dao.Update(ctx, user.Email, domainToDao(user))
 }
 
+func domainToDao(user domain.User) dao.User {
+	u := dao.User{}
+	if user.Birthday != "" {
+		u.Birthday = &user.Birthday
+	}
+	if user.Nickname != "" {
+		u.Nickname = &user.Nickname
+	}
+	if user.Intro != "" {
+		u.Intro = &user.Intro
+	}
+	return u
+}
 func daoToDomain(user dao.User) domain.User {
-	return domain.User{
+	u := domain.User{
 		Email:    user.Email,
 		Password: user.Password,
-		Birthday: user.Birthday,
-		Nickname: user.Nickname,
-		Intro:    user.Intro,
 	}
+	if user.Birthday != nil {
+		u.Birthday = *user.Birthday
+	}
+	if user.Nickname == nil {
+		u.Nickname = *user.Nickname
+	}
+	if user.Intro == nil {
+		u.Intro = *user.Intro
+	}
+	return u
 }

--- a/application/internal/usecase/user.go
+++ b/application/internal/usecase/user.go
@@ -62,8 +62,9 @@ func (u *userUseCase) LogIn(ctx context.Context, user domain.User) error {
 }
 
 func (u *userUseCase) Edit(ctx context.Context, user domain.User) error {
-	//TODO implement me
-	panic("implement me")
+	email := ctx.Value("user_id").(string)
+	user.Email = email
+	return u.repo.UpdateUser(ctx, user)
 }
 
 func (u *userUseCase) GetProfile(ctx context.Context, user domain.User) (domain.User, error) {

--- a/application/internal/usecase/user.go
+++ b/application/internal/usecase/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/Jadepypy/distributed-social-media/application/internal/domain"
 	"github.com/Jadepypy/distributed-social-media/application/internal/repository"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type UserUseCase interface {
@@ -22,14 +23,42 @@ func NewUserUseCase(repo repository.UserRepository) UserUseCase {
 		repo: repo,
 	}
 }
+
+func hashPassword(password string) ([]byte, error) {
+	pwd := []byte(password)
+	hash, err := bcrypt.GenerateFromPassword(pwd, bcrypt.DefaultCost)
+	if err != nil {
+		return []byte{}, err
+	}
+	return hash, nil
+}
+
 func (u *userUseCase) SignUp(ctx context.Context, user domain.User) error {
-	//TODO implement me
-	panic("implement me")
+	hashedPassword, err := hashPassword(user.Password)
+	if err != nil {
+		return err
+	}
+	user.Password = string(hashedPassword)
+
+	err = u.repo.CreateUser(ctx, user)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (u *userUseCase) LogIn(ctx context.Context, user domain.User) error {
-	//TODO implement me
-	panic("implement me")
+	existingUser, err := u.repo.GetUserByEmail(ctx, user.Email)
+	if err != nil {
+		return err
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(existingUser.Password), []byte(user.Password)); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (u *userUseCase) Edit(ctx context.Context, user domain.User) error {

--- a/application/internal/usecase/user_test.go
+++ b/application/internal/usecase/user_test.go
@@ -1,0 +1,17 @@
+package usecase
+
+import (
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+	"testing"
+)
+
+func Test_hashPassword(t *testing.T) {
+	var err error
+	password := "test"
+	hashedPassword, err := hashPassword(password)
+	assert.Nil(t, err)
+
+	err = bcrypt.CompareHashAndPassword(hashedPassword, []byte(password))
+	assert.Nil(t, err)
+}

--- a/application/main.go
+++ b/application/main.go
@@ -2,18 +2,27 @@ package main
 
 import (
 	"github.com/Jadepypy/distributed-social-media/application/internal"
+	"github.com/Jadepypy/distributed-social-media/application/internal/middleware"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 func main() {
 	r := gin.Default()
+
+	// TODO: add cookie settings
+	store := cookie.NewStore([]byte("secret"))
+	r.Use(sessions.Sessions("dsm", store))
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"message": "pong",
 		})
 	})
 
+	l := middleware.LogInMiddlewareBuilder{}
+	r.Use(l.CheckLogIn())
 	u := internal.NewUserHandler()
 	u.RegisterRoutes(r)
 

--- a/application/script/postgres/init.sql
+++ b/application/script/postgres/init.sql
@@ -1,9 +1,12 @@
 create database dsm;
 
 CREATE TABLE users (
-                       user_id SERIAL PRIMARY KEY,
+                       id SERIAL PRIMARY KEY,
                        email VARCHAR(255) UNIQUE NOT NULL,
-                       name VARCHAR(100),
+                       password VARCHAR(255),
+                       nickname VARCHAR(100),
                        birthday DATE,
-                       intro TEXT
+                       intro TEXT,
+                       created_at INT,
+                       updated_at INT
 );

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.9.1
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/crypto v0.16.0
 	gorm.io/driver/postgres v1.5.4
 	gorm.io/gorm v1.25.5
 )
@@ -12,6 +14,7 @@ require (
 	github.com/bytedance/sonic v1.10.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -31,11 +34,11 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.6.0 // indirect
-	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,15 @@ require (
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gin-contrib/sessions v0.0.5 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.16.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/securecookie v1.1.1 // indirect
+	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/gin-contrib/sessions v0.0.5 h1:CATtfHmLMQrMNpJRgzjWXD7worTh7g7ritsQfmF+0jE=
+github.com/gin-contrib/sessions v0.0.5/go.mod h1:vYAuaUPqie3WUSsft6HUlCjlwwoJQs97miaG2+7neKY=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg=
@@ -32,6 +34,12 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=

--- a/journal.md
+++ b/journal.md
@@ -1,6 +1,6 @@
 ## Week 1
 - [ ] Initialize web framework
 - [ ] Initialize database
-- [ ] Implement sign in
+- [ ] Implement sign in with cookie/session
 - [ ] Implement sign up
 - [ ] Implement get/edit user profile


### PR DESCRIPTION
作业：实现编辑功能
你需要完善 /users/edit 对应的接口。要求：

允许用户补充基本个人信息，包括：
昵称：字符串，你需要考虑允许的长度。
生日：前端输入为 1992-01-01 这种字符串。
个人简介：一段文本，你需要考虑允许的长度。
尝试校验这些输入，并且返回准确的信息。
修改 /users/profile 接口，确保这些信息也能输出到前端。
不要求你开发前端页面。提交作业的时候，顺便提交 postman 响应截图。加一个 README 文件，里面贴个图。

就是补充 record 分支上的 Edit 和 Profile 接口。

PS：暂时不要求上传头像，后面我们讲到 OSS 之后直接用 OSS。


<img width="370" alt="image" src="https://github.com/Jadepypy/distributed-social-media/assets/53862428/4d0fae26-d779-4482-9b8f-6d06684712fe">
<img width="408" alt="image" src="https://github.com/Jadepypy/distributed-social-media/assets/53862428/80ad68b2-da89-4f82-9f4b-78737145b7b0">

